### PR TITLE
Fixed issue where max health was not being set correctly

### DIFF
--- a/BroMaker/src/BroMakerLib/Extensions/ICustomHeroExtensions.cs
+++ b/BroMaker/src/BroMakerLib/Extensions/ICustomHeroExtensions.cs
@@ -138,7 +138,14 @@ namespace BroMakerLib
             if(!hero.info.beforeAwake.ContainsKey("specialGrenade.playerNum"))
                 hero.info.beforeAwake.Add("specialGrenade.playerNum", LoadHero.playerNum);
             if(!hero.info.beforeAwake.ContainsKey("maxHealth"))
+            {
                 hero.info.beforeAwake.Add("maxHealth", 1);
+                hero.info.beforeAwake.Add("health", 1);
+            }
+            else if(!hero.info.beforeAwake.ContainsKey("health"))
+            {
+                hero.info.beforeAwake.Add("health", hero.info.beforeAwake.GetFieldValue("maxHealth"));
+            }
             hero.character.specialGrenade.playerNum = LoadHero.playerNum;
         }
 


### PR DESCRIPTION
It looks like the max health value is being set to the current health of the unit in NetworkedUnit's awake function, so we need to set the health value in order for the maxHealth not to be reset to 3.